### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "homepage": "https://github.com/grazulex/laravel-devtoolbox",
     "require": {
         "php": "^8.3",
-        "illuminate/support": "^12.19",
+        "illuminate/support": "^11.0",
         "nesbot/carbon": "^3.10"
     },
     "require-dev": {


### PR DESCRIPTION
for Laravel 11 support

## Description

Library description includes Laravel 11+ support but I cannot install it into my project which I use Laravel 11. The reason is "illuminate/support" version. I suggest to downgrade the dependency version for Laravel 11.